### PR TITLE
Fix missing Caps Lock indicator

### DIFF
--- a/rk/r65/keyboard.json
+++ b/rk/r65/keyboard.json
@@ -22,6 +22,10 @@
         "rows": ["A1", "A2", "A3", "A4", "C13"]
     },
     "processor": "WB32FQ95",
+    "indicators": {
+        "caps_lock": "B0",
+        "on_state": 0
+    },
     "rgb_matrix": {
         "animations": {
             "alphas_mods": true,


### PR DESCRIPTION
KB now properly turns on LED for Cap Lock.

Note that Win Lock and Apple are still missing,
they are accessible on ports:
- WinLock = B10
- Mac = B11

I think it needs custom code to enable those LEDs though.

**Note:** The pins are "reversed", to turn it on you send a 0